### PR TITLE
fix: cap flask-sqla <3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ extras_require = {
     ],
     'flask': ['Flask>=0.9'],
     'flask-login': ['Flask-Login>=0.2.9'],
-    'flask-sqlalchemy': ['Flask-SQLAlchemy>=1.0'],
+    'flask-sqlalchemy': ['Flask-SQLAlchemy>=1.0, <3.0.0'],
     'flexmock': ['flexmock>=0.9.7'],
     'i18n': ['SQLAlchemy-i18n>=0.8.4,!=1.1.0'],
 }


### PR DESCRIPTION
Discarding V3.0.0 for Flask-Sqlalchemy as it's causing import [issue](https://github.com/kvesteri/sqlalchemy-continuum/actions/runs/3187069268/jobs/5198277223)