### PR TITLE
Add python_requires 3.6+ to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms='any',
+    python_requires='>=3.6.0',
     install_requires=[
         'SQLAlchemy>=1.0.8',
         'SQLAlchemy-Utils>=0.30.12'
@@ -69,13 +70,7 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]


### PR DESCRIPTION
For issue [#10 ](https://github.com/corridor/sqlalchemy-history/issues/10#event-7543753999)
Enforce a python version greater than 3.6 during install. 
For pypi it may also be desirable to remove the following lines from setup.py as these versions will no longer be installable.
`73 'Programming Language :: Python :: 2',`
`74 'Programming Language :: Python :: 2.7',`
`76 'Programming Language :: Python :: 3.4',`
`77 'Programming Language :: Python :: 3.5',`