### PR TITLE
Refactor[#14] : Remove support for SQLA<1.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: "Test"
 
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - "docs/**"
   pull_request:
@@ -27,7 +29,7 @@ jobs:
 #          - "3.10"
 #          - "pypy-3.7"
         sqlalchemy-version:
-          - "<1.4"
+          # - "<1.4"
           - ">=1.4"
         db-engine:
           - sqlite

--- a/sqlalchemy_history/factory.py
+++ b/sqlalchemy_history/factory.py
@@ -7,10 +7,8 @@ class ModelFactory(object):
         in declarative model registry.
         """
         Base = manager.declarative_base
-        try:
-            registry = Base.registry._class_registry
-        except AttributeError:  # SQLAlchemy < 1.4
-            registry = Base._decl_class_registry
+        registry = Base.registry._class_registry
+
         if self.model_name not in registry:
             return self.create_class(manager)
         return registry[self.model_name]

--- a/sqlalchemy_history/fetcher.py
+++ b/sqlalchemy_history/fetcher.py
@@ -85,19 +85,13 @@ class VersionObjectFetcher(object):
             )
             .correlate(table)
         )
-        try:
-            return query.scalar_subquery()
-        except AttributeError:  # SQLAlchemy < 1.4
-            return query.as_scalar()
+        return query.scalar_subquery()
 
     def _next_prev_query(self, obj, next_or_prev="next"):
         session = sa.orm.object_session(obj)
 
         subquery = self._transaction_id_subquery(obj, next_or_prev=next_or_prev)
-        try:
-            subquery = subquery.scalar_subquery()
-        except AttributeError:  # SQLAlchemy < 1.4
-            subquery = subquery.as_scalar()
+        subquery = subquery.scalar_subquery()
 
         return session.query(obj.__class__).filter(
             sa.and_(getattr(obj.__class__, tx_column_name(obj)) == subquery, *parent_criteria(obj))

--- a/sqlalchemy_history/relationship_builder.py
+++ b/sqlalchemy_history/relationship_builder.py
@@ -48,11 +48,7 @@ class RelationshipBuilder(object):
                 reflector(self.property.primaryjoin),
             )
         )
-        try:
-            subquery = subquery.scalar_subquery()
-        except AttributeError:  # SQLAlchemy < 1.4
-            subquery = subquery.as_scalar()
-
+        subquery = subquery.scalar_subquery()
         return getattr(self.remote_cls, tx_column) == subquery
 
     def query(self, obj):

--- a/sqlalchemy_history/schema.py
+++ b/sqlalchemy_history/schema.py
@@ -15,10 +15,7 @@ def get_end_tx_column_query(table, end_tx_column_name="end_transaction_id", tx_c
             *[getattr(v3.c, pk) == getattr(v1.c, pk) for pk in primary_keys if pk != tx_column_name],
         )
     )
-    try:
-        tx_criterion = tx_criterion.scalar_subquery()
-    except AttributeError:  # SQLAlchemy < 1.4
-        tx_criterion = tx_criterion.as_scalar()
+    tx_criterion = tx_criterion.scalar_subquery()
     return sa.select(
         columns=[getattr(v1.c, column) for column in primary_keys]
         + [getattr(v2.c, tx_column_name).label(end_tx_column_name)],

--- a/sqlalchemy_history/transaction.py
+++ b/sqlalchemy_history/transaction.py
@@ -93,10 +93,7 @@ class TransactionFactory(ModelFactory):
             if manager.user_cls:
                 user_cls = manager.user_cls
                 Base = manager.declarative_base
-                try:
-                    registry = Base.registry._class_registry
-                except AttributeError:  # SQLAlchemy < 1.4
-                    registry = Base._decl_class_registry
+                registry = Base.registry._class_registry
 
                 if isinstance(user_cls, str):
                     try:

--- a/sqlalchemy_history/unit_of_work.py
+++ b/sqlalchemy_history/unit_of_work.py
@@ -224,10 +224,7 @@ class UnitOfWork(object):
                 subquery = self.version_validity_subquery(
                     parent, version_obj, alias=sa.orm.aliased(class_.__table__)
                 )
-                try:
-                    subquery = subquery.scalar_subquery()
-                except AttributeError:  # SQLAlchemy < 1.4
-                    subquery = subquery.as_scalar()
+                subquery = subquery.scalar_subquery()
 
                 query = session.query(class_.__table__).filter(
                     sa.and_(

--- a/tests/test_changeset.py
+++ b/tests/test_changeset.py
@@ -88,10 +88,7 @@ class TestChangeSetWhenParentContainsAdditionalColumns(ChangeSetTestCase):
         subquery = (
             sa.select([sa.func.count(Tag.id)]).where(Tag.article_id == Article.id).correlate_except(Tag)
         )
-        try:
-            subquery = subquery.scalar_subquery()
-        except AttributeError:  # SQLAlchemy < 1.4
-            subquery = subquery.as_scalar()
+        subquery = subquery.scalar_subquery()
         Article.tag_count = sa.orm.column_property(subquery)
 
         self.Article = Article


### PR DESCRIPTION
The PR contains to commits 
1. to remove github action checks for SQLA<1.4 and avoid checks for push unless push is on master branch
2. Remove code where SQLA<1.4 is being supported