### PR TITLE
Fix 54: Add support for Association Proxy in Versioned class

### DIFF
--- a/sqlalchemy_history/builder.py
+++ b/sqlalchemy_history/builder.py
@@ -4,6 +4,7 @@ from functools import wraps
 
 import sqlalchemy as sa
 from sqlalchemy_utils.functions import get_declarative_base
+from sqlalchemy_history.utils import get_association_proxy_mapping, version_class
 
 from sqlalchemy_history.model_builder import ModelBuilder
 from sqlalchemy_history.relationship_builder import RelationshipBuilder
@@ -139,6 +140,7 @@ class Builder(object):
            does not create multiple version classes
         5. Build aliases for columns.
         6. Assign all versioned attributes to use active history.
+        7. Add Association proxy for Versioned Models.
 
         """
         if not self.manager.options["versioning"]:
@@ -160,6 +162,7 @@ class Builder(object):
         self.build_relationships(pending_classes_copies)
         self.enable_active_history(pending_classes_copies)
         self.create_column_aliases(pending_classes_copies)
+        self.create_association_proxies(pending_classes_copies)
 
     def enable_active_history(self, version_classes):
         """
@@ -191,3 +194,17 @@ class Builder(object):
                         continue
 
                     version_class_mapper.add_property(key, sa.orm.column_property(version_class_column))
+
+    def create_association_proxies(self, version_classes):
+        """
+        Create Association proxy for Column of Versioned Models from Original Model
+        """
+        for cls in version_classes:
+            assoc_prox_maps = get_association_proxy_mapping(cls)
+            for attr, proxy in assoc_prox_maps.items():
+                versioned_target_class = version_class(cls)
+                setattr(
+                    versioned_target_class,
+                    attr,
+                    property(fget=proxy.__get__, fset=proxy.__set__, fdel=proxy.__delete__),
+                )

--- a/sqlalchemy_history/utils.py
+++ b/sqlalchemy_history/utils.py
@@ -434,3 +434,12 @@ class VersioningClauseAdapter(sa.sql.visitors.ReplacingCloningVisitor):
 
 def adapt_columns(expr):
     return VersioningClauseAdapter().traverse(expr)
+
+
+def get_association_proxy_mapping(klass):
+    """Get Association proxy mappings for ORM Models"""
+    association_proxy_mapping = {}
+    for attr, attr_value in sa.inspect(klass).all_orm_descriptors.items():
+        if isinstance(attr_value, sa.ext.associationproxy.AssociationProxy):
+            association_proxy_mapping[attr] = attr_value
+    return association_proxy_mapping

--- a/tests/test_association_proxy.py
+++ b/tests/test_association_proxy.py
@@ -1,0 +1,44 @@
+import sqlalchemy as sa
+from sqlalchemy_history.utils import get_association_proxy_mapping, version_class
+
+from tests import TestCase
+
+
+class TestAssociationProxy(TestCase):
+    def create_models(self):
+        class Article(self.Model):
+            __tablename__ = "article"
+            __versioned__ = {}
+
+            id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+            name = sa.Column(sa.Unicode(255), nullable=False)
+            content = sa.Column(sa.UnicodeText)
+            description = sa.Column(sa.UnicodeText)
+
+            upanaam = sa.ext.associationproxy.association_proxy("tags", "name")
+
+        class Tag(self.Model):
+            __tablename__ = "tag"
+            __versioned__ = {}
+
+            id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+            name = sa.Column(sa.Unicode(255))
+            article_id = sa.Column(sa.Integer, sa.ForeignKey(Article.id))
+            article = sa.orm.relationship(Article, backref="tags")
+
+        self.Article = Article
+        self.Tag = Tag
+
+    def test_association_proxy_mapping(self):
+        assoc_mapping = get_association_proxy_mapping(self.Article)
+        assert len(assoc_mapping) == 1
+        assert list(assoc_mapping.keys())[0] == "upanaam"
+        assert isinstance(assoc_mapping["upanaam"], sa.ext.associationproxy.AssociationProxy)
+
+    def test_association_proxy_detection(self):
+        """
+        Currently Versioned Model have a proxy mapped as a property due limitation in the way relationships are handled,
+        For now a property in versioned model should be available for proxy attributes of orginal model
+        """
+        assert issubclass(type(self.Article.upanaam), sa.ext.associationproxy.AssociationProxyInstance)
+        assert isinstance(version_class(self.Article).upanaam, property)


### PR DESCRIPTION
Based on this discussion in this [thread](https://github.com/sqlalchemy/sqlalchemy/discussions/8940) and adding workaround for assoc proxy handling in versioned Model. will have to revisit once a solution is available for handling relation among versioned models.