### PR TITLE
Cache previous/next/etc. in VersionClassBase

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ python = "^3.6"
 
 SQLAlchemy = ">=1.4,<2"
 SQLAlchemy-Utils = ">=0.30.12"
+cached-property = "*"
 
 [tool.poetry.dev-dependencies]
 black = {version = "*", allow-prereleases = true}

--- a/sqlalchemy_history/version.py
+++ b/sqlalchemy_history/version.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+from cached_property import cached_property
 
 from sqlalchemy_history.reverter import Reverter
 from sqlalchemy_history.utils import (
@@ -9,7 +10,7 @@ from sqlalchemy_history.utils import (
 
 
 class VersionClassBase(object):
-    @property
+    @cached_property
     def previous(self):
         """Returns the previous version relative to this version in the version
         history. If current version is the first version this method returns
@@ -19,7 +20,7 @@ class VersionClassBase(object):
         """
         return get_versioning_manager(self).fetcher(parent_class(self.__class__)).previous(self)
 
-    @property
+    @cached_property
     def next(self):
         """Returns the next version relative to this version in the version
         history. If current version is the last version this method returns
@@ -29,7 +30,7 @@ class VersionClassBase(object):
         """
         return get_versioning_manager(self).fetcher(parent_class(self.__class__)).next(self)
 
-    @property
+    @cached_property
     def index(self):
         """ """
         return get_versioning_manager(self).fetcher(parent_class(self.__class__)).index(self)


### PR DESCRIPTION
Cache some properties in VersionClassBase as it won't really change and can improve performance significantly by avoiding extra queries

Tested this in my own application and also in a shell:
```py
>>> class A:
...     @cached_property
...     def abc(self):
...         print("test")
...         return 1
...
>>> a = A()
>>> a.abc
test
1
>>> a.abc
1
```