### PR TITLE
fix(#25): handle attributes which are not accessible in ORM

### DIFF
--- a/sqlalchemy_history/builder.py
+++ b/sqlalchemy_history/builder.py
@@ -178,7 +178,10 @@ class Builder(object):
         """
         for cls in version_classes:
             for prop in sa.inspect(cls).iterate_properties:
-                getattr(cls, prop.key).impl.active_history = True
+                if hasattr(cls, prop.key):
+                    # Mapper Arg `_sa_polymorphic_on` appear as columnproperty but is not attr of cls
+                    # Giving AttrError
+                    getattr(cls, prop.key).impl.active_history = True
 
     def create_column_aliases(self, version_classes):
         """

--- a/tests/reported_bugs/test_bug_25_polymorphic_on_attr.py
+++ b/tests/reported_bugs/test_bug_25_polymorphic_on_attr.py
@@ -1,0 +1,44 @@
+import sqlalchemy as sa
+from tests import TestCase
+
+
+class TestBug25(TestCase):
+    # ref: https://github.com/corridor/sqlalchemy-history/issues/25
+    def create_models(self):
+        class Writer(self.Model):
+            __tablename__ = "writer"
+            __versioned__ = {}
+
+            id = sa.Column(sa.Integer, sa.Sequence(f"{__tablename__}_seq"), primary_key=True)
+            name = sa.Column(sa.String(255))
+            type = sa.Column(sa.String(255))
+
+            __mapper_args__ = {
+                "polymorphic_on": (
+                    sa.case(
+                        [(type.in_(["poet", "lyricist"]), "bard")],
+                        else_=type,
+                    )
+                ),
+                "polymorphic_identity": "writer",
+            }
+
+        class Author(self.Model):
+            __tablename__ = "author"
+            __versioned__ = {}
+            id = sa.Column(sa.Integer, sa.Sequence(f"{__tablename__}_seq"), primary_key=True)
+            name = sa.Column(sa.String(255))
+
+            __mapper_args__ = {
+                "polymorphic_identity": "author",
+            }
+
+        self.Writer = Writer
+        self.Author = Author
+
+    def test_inserting_entries(self):
+        writer = self.Writer(name="Writer 1")
+        author = self.Author(name="Author 1")
+        self.session.add(writer)
+        self.session.add(author)
+        self.session.commit()


### PR DESCRIPTION
doing a check for property key before enabling active_history to make sure it can be directly accessed by parent_cls