### PR TITLE
Ensure txn-id is incremental using sqlalchemy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Black Validation
         uses: psf/black@stable
+        with:
+          version: "22.8.0"  # Last version which can be used in py3.6 and py3.7
       - name: Check Flake8 Formatting
         uses: py-actions/flake8@v2
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,13 @@ Changelog
 
 Here you can see the full list of changes between each release.
 
+Unreleased
+^^^^^^^^^^
+
+-   Set the Transaction.id ourselves to ensure that the values are always ascending
+    order. This leaves a slight chance for a race condition - but will safeguard us
+    from DB specific nuances in autoincrement handling
+
 2.0.0 (2023-02-02)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,9 @@ curl -sSL https://install.python-poetry.org | python3 -
 poetry install   # Poetry creates a virtual environment in your local
 # NOTE: If poetry is not set in your $PATH variable you can use
 # '~/.local/share/pypoetry/venv/bin/poetry install' instead!
+
 # Activate this virtual environment in your local by calling
-source ./.venv/bin/activate
+poetry shell
 ```
 - Checkout branch with name relevant to issue issue you are working
 ```
@@ -38,10 +39,11 @@ git checkout -b add-issue-num
 - Make changes as per the issue you are working on and add/modify testfile(s) if you are adding new feature or fixing bugs in existing code
 - Before commiting, verify if the changes are working in your local system
 ```
-export DB=sqlite # for local dev testing
-pytest
+# Run tests locally
+DB=sqlite poetry run pytest
+
 # Lint
-black .
+poetry run black .
 ```
 - Add commit for your changes with message title and message description brifly explaining the approach
     - Keep commit message title 72 characters

--- a/tests/inheritance/test_concrete_inheritance.py
+++ b/tests/inheritance/test_concrete_inheritance.py
@@ -67,9 +67,9 @@ class TestConreteTableInheritance(TestCase):
         self.session.add(textitem)
         self.session.commit()
 
-        assert type(textitem.versions[0]) == self.TextItemVersion
-        assert type(article.versions[0]) == self.ArticleVersion
-        assert type(blogpost.versions[0]) == self.BlogPostVersion
+        assert type(textitem.versions[0]) is self.TextItemVersion
+        assert type(article.versions[0]) is self.ArticleVersion
+        assert type(blogpost.versions[0]) is self.BlogPostVersion
 
     def test_transaction_changed_entities(self):
         article = self.Article()

--- a/tests/inheritance/test_join_table_inheritance.py
+++ b/tests/inheritance/test_join_table_inheritance.py
@@ -57,9 +57,9 @@ class JoinTableInheritanceTestCase(TestCase):
         self.session.add(textitem)
         self.session.commit()
 
-        # assert type(textitem.versions[0]) == self.TextItemVersion
-        assert type(article.versions[0]) == self.ArticleVersion
-        assert type(blogpost.versions[0]) == self.BlogPostVersion
+        # assert type(textitem.versions[0]) is self.TextItemVersion
+        assert type(article.versions[0]) is self.ArticleVersion
+        assert type(blogpost.versions[0]) is self.BlogPostVersion
 
     def test_all_tables_contain_transaction_id_column(self):
         tx_column = self.options["transaction_column_name"]

--- a/tests/inheritance/test_single_table_inheritance.py
+++ b/tests/inheritance/test_single_table_inheritance.py
@@ -65,9 +65,9 @@ class SingleTableInheritanceTestCase(TestCase):
         self.session.add(textitem)
         self.session.commit()
 
-        assert type(textitem.versions[0]) == self.TextItemVersion
-        assert type(article.versions[0]) == self.ArticleVersion
-        assert type(blogpost.versions[0]) == self.BlogPostVersion
+        assert type(textitem.versions[0]) is self.TextItemVersion
+        assert type(article.versions[0]) is self.ArticleVersion
+        assert type(blogpost.versions[0]) is self.BlogPostVersion
 
     def test_transaction_changed_entities(self):
         article = self.Article()


### PR DESCRIPTION
In sqlalchemy, lock the DB and ensure that the txn-id will always be incrementing.
This is an assumption that is baked into the library and so we should ensure this assumption never breaks for txn-id atleast.