### PR TITLE
fix(23): allow viewonly relationship for many to many

### DIFF
--- a/sqlalchemy_history/relationship_builder.py
+++ b/sqlalchemy_history/relationship_builder.py
@@ -336,10 +336,8 @@ class RelationshipBuilder(object):
         except ClassNotVersioned:
             self.remote_cls = self.property.mapper.class_
 
-        if (
-            self.property.secondary is not None
-            and not self.property.viewonly
-            and not self.manager.is_excluded_property(self.model, self.property.key)
+        if self.property.secondary is not None and not self.manager.is_excluded_property(
+            self.model, self.property.key
         ):
             self.build_association_version_tables()
 

--- a/tests/relationships/test_many_to_many_relations.py
+++ b/tests/relationships/test_many_to_many_relations.py
@@ -2,7 +2,6 @@ import pytest
 import datetime
 from pytest import mark
 import sqlalchemy as sa
-from sqlalchemy_history import versioning_manager
 
 from tests import TestCase, create_test_cases
 
@@ -214,48 +213,6 @@ class ManyToManyRelationshipsTestCase(TestCase):
 
 
 create_test_cases(ManyToManyRelationshipsTestCase)
-
-
-class TestManyToManyRelationshipWithViewOnly(TestCase):
-    def create_models(self):
-        class Article(self.Model):
-            __tablename__ = "article"
-            __versioned__ = {"base_classes": (self.Model,)}
-
-            id = sa.Column(
-                sa.Integer, sa.Sequence(f"{__tablename__}_seq"), autoincrement=True, primary_key=True
-            )
-            name = sa.Column(sa.Unicode(255))
-
-        article_tag = sa.Table(
-            "article_tag",
-            self.Model.metadata,
-            sa.Column(
-                "article_id",
-                sa.Integer,
-                sa.ForeignKey("article.id"),
-                primary_key=True,
-            ),
-            sa.Column("tag_id", sa.Integer, sa.ForeignKey("tag.id"), primary_key=True),
-        )
-
-        class Tag(self.Model):
-            __tablename__ = "tag"
-            __versioned__ = {"base_classes": (self.Model,)}
-
-            id = sa.Column(
-                sa.Integer, sa.Sequence(f"{__tablename__}_seq"), autoincrement=True, primary_key=True
-            )
-            name = sa.Column(sa.Unicode(255))
-
-        Tag.articles = sa.orm.relationship(Article, secondary=article_tag, viewonly=True)
-
-        self.article_tag = article_tag
-        self.Article = Article
-        self.Tag = Tag
-
-    def test_does_not_add_association_table_to_manager_registry(self):
-        assert self.article_tag not in versioning_manager.version_table_map
 
 
 class TestManyToManySelfReferential(TestCase):


### PR DESCRIPTION
couldn't think of a reason why we should not allow many to many relation for assoc versioned table.
saw that there is a explicit test to not allow same removed it and removed the check that was stopping it