### PR TITLE
fix(97): version table does not require defaults

### DIFF
--- a/sqlalchemy_history/table_builder.py
+++ b/sqlalchemy_history/table_builder.py
@@ -25,6 +25,8 @@ class ColumnReflector(object):
         column_copy = column._copy()
         column_copy.unique = False
         column_copy.onupdate = None
+        column_copy.default = None
+        column_copy.server_default = None
         if column_copy.autoincrement:
             column_copy.autoincrement = False
         if column_copy.name == self.option("transaction_column_name"):

--- a/tests/builders/test_table_builder.py
+++ b/tests/builders/test_table_builder.py
@@ -73,6 +73,10 @@ class TestTableBuilderWithOnUpdate(TestCase):
         table = version_class(self.Article).__table__
         assert table.c.last_update.onupdate is None
 
+    def test_takes_out_default_triggers(self):
+        table = version_class(self.Article).__table__
+        assert table.c.last_update.default is None
+
 
 @mark.skipif("os.environ.get('DB') in ['sqlite']", reason="sqlite doesn't have a concept of schema")
 class TestTableBuilderInOtherSchema(TestCase):

--- a/tests/reported_bugs/test_bug_97_default_values_in_version_table.py
+++ b/tests/reported_bugs/test_bug_97_default_values_in_version_table.py
@@ -1,0 +1,30 @@
+import sqlalchemy as sa
+from copy import copy
+from tests import TestCase
+
+
+class TestBug97(TestCase):
+    # ref: https://github.com/corridor/sqlalchemy-history/issues/97
+    def create_models(self):
+        class Article(self.Model):
+            __tablename__ = "article"
+            __versioned__ = copy(self.options)
+
+            id = sa.Column(
+                sa.Integer, sa.Sequence(f"{__tablename__}_seq"), autoincrement=True, primary_key=True
+            )
+            name = sa.Column(sa.Unicode(255), server_default="default name")
+            content = sa.Column(sa.UnicodeText)
+
+        self.Article = Article
+
+    def test_should_not_pick_default_entry_in_versions(self):
+        article = self.Article(name="Article 1")
+        self.session.add(article)
+        self.session.commit()
+        article.name = None
+        self.session.add(article)
+        self.session.commit()
+        assert article.name is None
+        assert article.versions.count() == 2
+        assert article.versions[-1].name is None


### PR DESCRIPTION
since version table store entries at any point in time in DB of original table, we execute insert statements for them, now there are scenerios where if a user is setting a value explicitly as None in original table, version table is still picking default value causing inconsistency b/w version table and original table