### PR TITLE
fix(#114): properly handle association proxy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,9 +58,9 @@ For completeness, below is a working example.
 from sqlalchemy_history import make_versioned
 from sqlalchemy import Column, Integer, Unicode, UnicodeText, create_engine
 try:
-   from sqlalchemy.ext.declarative import declarative_base
-except ImportError:  # sqla > 2.x
    from sqlalchemy.orm import declarative_base
+except ImportError:  # sqla < 2.x
+   from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import create_session, configure_mappers
 make_versioned(user_cls=None)
 Base = declarative_base()

--- a/sqlalchemy_history/builder.py
+++ b/sqlalchemy_history/builder.py
@@ -215,12 +215,12 @@ class Builder(object):
         """
         for cls in version_classes:
             assoc_prox_maps = get_association_proxies(cls)
-            for key, prop in assoc_prox_maps.items():
+            for key in assoc_prox_maps.keys():
                 versioned_target_class = version_class(cls)
                 setattr(
                     versioned_target_class,
                     key,
-                    property(fget=prop.__get__),
+                    property(fget=getattr(cls, key).get),
                 )
 
     def create_hybrid_properties(self, version_classes):


### PR DESCRIPTION
we added association proxy support in versioned class but it was incorrect as we were setting proxy attribute to versioned class and we didn't caught it because we didn't have test for that so added that.