### PR TITLE
chore: bump ci to to test with 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
             matrix:
                 python-version:
                     - "3.7"
-                    - "3.11"
+                    - "3.12"
                 DB:
                     - "sqlite"
                     - "mssql"


### PR DESCRIPTION
py 3.12 is released so bumping the ci test configuration to test with that.