### PR TITLE
fix(#123): add sqla matrix in poetry environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,6 +103,7 @@ jobs:
                   poetry run pytest -x --cov --cov-report=lcov
               env:
                   DB: ${{ matrix.DB }}
+                  SQLA_20_WARNING: 1
             - name: send coverage data to Coveralls
               env:
                   github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install --upgrade poetry 
                   poetry install
-                  pip install 'sqlalchemy${{ matrix.sqla }}'
+                  poetry add 'sqlalchemy${{ matrix.sqla }}'
             - name: install oracle dependencies
               if: ${{ matrix.DB == 'oracle' }}
               run:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -118,7 +118,7 @@ class TestCase(object):
     @pytest.fixture(autouse=True)
     def setup_session(self, setup_tables):
         Session = sessionmaker(bind=self.connection)
-        self.session = Session(autoflush=False)
+        self.session = Session(autoflush=False, future=True)
         yield
         self.session.rollback()
         uow_leaks = versioning_manager.units_of_work

--- a/tests/builders/test_table_builder.py
+++ b/tests/builders/test_table_builder.py
@@ -117,7 +117,14 @@ class TestTableBuilderInOtherSchema(TestCase):
                     #       so we just try to create if fails we continue
                     raise
         finally:
-            self.connection.commit()
+            try:
+                # NOTE: Sqlalchemy >= 2.0.0 requires user to explicitly do commit for a given transaction
+                # ref: https://docs.sqlalchemy.org/en/20/core/connections.html#commit-as-you-go
+                self.connection.commit()
+            except AttributeError:
+                # Sqlalchemy < 2.0.0 does not have commit available to connection as executes does commit
+                # automatically for a given ongoing transaction.
+                pass
         TestCase.create_tables(self)
 
     def test_created_tables_retain_schema(self):

--- a/tests/relationships/test_many_to_many_relations.py
+++ b/tests/relationships/test_many_to_many_relations.py
@@ -399,7 +399,14 @@ class TestManyToManySelfReferentialInOtherSchema(TestManyToManySelfReferential):
                     #       so we just try to create if fails we continue
                     raise
         finally:
-            self.connection.commit()
+            try:
+                # NOTE: Sqlalchemy >= 2.0.0 requires user to explicitly do commit for a given transaction
+                # ref: https://docs.sqlalchemy.org/en/20/core/connections.html#commit-as-you-go
+                self.connection.commit()
+            except AttributeError:
+                # Sqlalchemy < 2.0.0 does not have commit available to connection as executes does commit
+                # automatically for a given ongoing transaction.
+                pass
 
         TestManyToManySelfReferential.create_tables(self)
 
@@ -466,7 +473,14 @@ class TestManyToManyRelationshipsInOtherSchemaTestCase(ManyToManyRelationshipsTe
                     #       so we just try to create if fails we continue
                     raise
         finally:
-            self.connection.commit()
+            try:
+                # NOTE: Sqlalchemy >= 2.0.0 requires user to explicitly do commit for a given transaction
+                # ref: https://docs.sqlalchemy.org/en/20/core/connections.html#commit-as-you-go
+                self.connection.commit()
+            except AttributeError:
+                # Sqlalchemy < 2.0.0 does not have commit available to connection as executes does commit
+                # automatically for a given ongoing transaction.
+                pass
         ManyToManyRelationshipsTestCase.create_tables(self)
 
 

--- a/tests/test_association_proxy.py
+++ b/tests/test_association_proxy.py
@@ -50,7 +50,6 @@ class TestAssociationProxy(TestCase):
 
     def test_association_proxy_retrieval(self):
         tag = self.Tag(name="tag1")
-        self.session.add(tag)
         article = self.Article(name="article1", tags=[tag])
         self.session.add(article)
         self.session.commit()

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,6 +1,6 @@
 from pytest import raises
 import sqlalchemy as sa
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy_history import (
     versioning_manager,
     ImproperlyConfigured,

--- a/tests/test_custom_schema.py
+++ b/tests/test_custom_schema.py
@@ -1,7 +1,7 @@
 import os
 import sqlalchemy as sa
 from pytest import mark
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from tests import TestCase
 
 

--- a/tests/test_custom_schema.py
+++ b/tests/test_custom_schema.py
@@ -69,7 +69,14 @@ class TestCustomSchema(TestCase):
                     #       so we just try to create if fails we continue
                     raise
         finally:
-            self.connection.commit()
+            try:
+                # NOTE: Sqlalchemy >= 2.0.0 requires user to explicitly do commit for a given transaction
+                # ref: https://docs.sqlalchemy.org/en/20/core/connections.html#commit-as-you-go
+                self.connection.commit()
+            except AttributeError:
+                # Sqlalchemy < 2.0.0 does not have commit available to connection as executes does commit
+                # automatically for a given ongoing transaction.
+                pass 
         TestCase.create_tables(self)
 
     def test_version_relations(self):

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -123,7 +123,14 @@ class TestAssigningUserClassInOtherSchema(TestCase):
                     #       so we just try to create if fails we continue
                     raise
         finally:
-            self.connection.commit()
+            try:
+                # NOTE: Sqlalchemy >= 2.0.0 requires user to explicitly do commit for a given transaction
+                # ref: https://docs.sqlalchemy.org/en/20/core/connections.html#commit-as-you-go
+                self.connection.commit()
+            except AttributeError:
+                # Sqlalchemy < 2.0.0 does not have commit available to connection as executes does commit
+                # automatically for a given ongoing transaction.
+                pass
         TestCase.create_tables(self)
 
     def test_can_build_transaction_model(self):


### PR DESCRIPTION
earlier sqlalchemy was being installed in pip environment but tests were running in poetry environment, so tests were not checked with sqlalchemy 1.4
Added sqlalchemy values from matrix in poetry environment. updated a testcase where connection.commit was being done, this is expected in sqla>=2.0 but in sqla<2 .execute does commit as well so added that in try, except block