### PR TITLE
fix(#125): handle utcnow for transaction module

### DIFF
--- a/sqlalchemy_history/transaction.py
+++ b/sqlalchemy_history/transaction.py
@@ -1,9 +1,8 @@
 """Transaction model makes transactions for history tables
 """
 
-from datetime import datetime
-
 from collections import OrderedDict
+import datetime
 import sqlalchemy as sa
 from sqlalchemy.ext.compiler import compiles
 
@@ -17,7 +16,7 @@ def compile_big_integer(element, compiler, **kw):
 
 
 class TransactionBase(object):
-    issued_at = sa.Column(sa.DateTime, default=datetime.utcnow)
+    issued_at = sa.Column(sa.DateTime, default=datetime.datetime.now(datetime.timezone.utc))
 
     @property
     def entity_names(self):

--- a/tests/relationships/test_many_to_many_relations.py
+++ b/tests/relationships/test_many_to_many_relations.py
@@ -1,9 +1,10 @@
-import os
 import datetime
+import os
 
 import sqlalchemy as sa
 from pytest import mark
 from sqlalchemy_history import versioning_manager
+
 
 from tests import TestCase, create_test_cases
 
@@ -34,7 +35,7 @@ class ManyToManyRelationshipsTestCase(TestCase):
                 sa.DateTime,
                 nullable=False,
                 server_default=sa.func.current_timestamp(),
-                default=datetime.datetime.utcnow,
+                default=datetime.datetime.now(datetime.timezone.utc),
             ),
         )
 

--- a/tests/reported_bugs/test_bug_27_datetime_insertion_issue.py
+++ b/tests/reported_bugs/test_bug_27_datetime_insertion_issue.py
@@ -1,6 +1,7 @@
 import datetime
 import sqlalchemy as sa
 from copy import copy
+
 from tests import TestCase
 
 
@@ -19,7 +20,7 @@ class TestBug27(TestCase):
                 sa.DateTime,
                 nullable=False,
                 server_default=sa.func.current_timestamp(),
-                default=datetime.datetime.utcnow,
+                default=datetime.datetime.now(datetime.timezone.utc)
             ),
         )
 

--- a/tests/schema/test_update_end_transaction_id.py
+++ b/tests/schema/test_update_end_transaction_id.py
@@ -4,6 +4,7 @@ from sqlalchemy_history import version_class
 from sqlalchemy_history.utils import version_table
 from sqlalchemy_history.schema import update_end_tx_column
 from sqlalchemy_history.operation import Operation
+
 from tests import TestCase, create_test_cases
 
 
@@ -24,7 +25,7 @@ class UpdateEndTransactionID(TestCase):
                 sa.DateTime,
                 nullable=False,
                 server_default=sa.func.current_timestamp(),
-                default=datetime.datetime.utcnow,
+                default=datetime.datetime.now(datetime.timezone.utc)
             ),
         )
 

--- a/tests/test_hybrid_property.py
+++ b/tests/test_hybrid_property.py
@@ -15,7 +15,7 @@ class TestHybridProperty(TestCase):
             name = sa.Column(sa.Unicode(255), nullable=False)
             content = sa.Column(sa.UnicodeText)
             description = sa.Column(sa.UnicodeText)
-            publish = sa.Column(sa.DateTime, default=datetime.datetime.utcnow)
+            publish = sa.Column(sa.DateTime, default=datetime.datetime.now(datetime.timezone.utc))
 
             @sa.ext.hybrid.hybrid_property
             def time_from_publish(self):

--- a/tests/utils/test_parent_table.py
+++ b/tests/utils/test_parent_table.py
@@ -1,5 +1,5 @@
-import datetime
 
+import datetime
 import pytest
 import sqlalchemy as sa
 from sqlalchemy_history.utils import parent_table, version_table
@@ -23,7 +23,7 @@ class TestParentTable(TestCase):
                 sa.DateTime,
                 nullable=False,
                 server_default=sa.func.current_timestamp(),
-                default=datetime.datetime.utcnow,
+                default=datetime.datetime.now(datetime.timezone.utc)
             ),
         )
 

--- a/tests/utils/test_version_table.py
+++ b/tests/utils/test_version_table.py
@@ -1,5 +1,5 @@
-import pytest
 import datetime
+import pytest
 import sqlalchemy as sa
 from tests import TestCase
 
@@ -23,7 +23,7 @@ class TestVersionTableDefault(TestCase):
                 sa.DateTime,
                 nullable=False,
                 server_default=sa.func.current_timestamp(),
-                default=datetime.datetime.utcnow,
+                default=datetime.datetime.now(datetime.timezone.utc)
             ),
         )
 


### PR DESCRIPTION
python 3.12 has deprecated the use of datetime.datetime.utcnow infavour of datetime.datetime.now(datetime.UTC).
ref: https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow

so added a utility method that tries to address this for different python version and used it in Transaction class and tests where we were setting default datetime value for datetime column.