### PR TITLE
fix(#127): Add MariaDB in CI test workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,20 @@ jobs:
                     - ">=1.4,<2"
                     - ">=2"
         services:
+            mariadb:
+                image: mariadb
+                ports:
+                    # Mysql is already exposed to 3306 port, so using 3307 instead
+                    - 3307:3306
+                env:
+                    MARIADB_DATABASE: sqlalchemy_history_test
+                    MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
+                options: >-
+                    --health-cmd "healthcheck.sh --connect --innodb_initialized"
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 3
+
             mysql:
                 image: mysql
                 ports:

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,7 +107,7 @@ print(article.name) # 'Some article'
 Primary reasons to create another library:
 
 - Be future looking and support sqlalchemy 1.4 and 2.x
-- Support multiple databases (sqlite, mysql, postgres, mssql, oracle)
+- Support multiple databases (sqlite, mysql, postgres, mssql, oracle, mariadb)
 - Focus on the history tracking and be as efficient as possible when doing it
 
 We found multiple libraries which has an implementation of history tracking:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -37,6 +37,8 @@ def get_dns_from_driver(driver):  # pragma: no cover
         return "mssql+pymssql://sa:MSsql2022@localhost:1433"
     elif driver == "oracle":
         return "oracle+cx_oracle://SYSTEM:Oracle2022@localhost:1521"
+    elif driver == "mariadb":
+        return "mysql+pymysql://root@localhost:3307/sqlalchemy_history_test"
     else:
         raise Exception("Unknown driver given: %r" % driver)
 


### PR DESCRIPTION
also test sqla-h with MariaDB, ran tests locally and tests didn't fail with MariaDB probably because it is very similar to MySQL DB.