### PR TITLE
force datetime with timezone on transaction issued_at

### DIFF
--- a/sqlalchemy_history/transaction.py
+++ b/sqlalchemy_history/transaction.py
@@ -16,7 +16,7 @@ def compile_big_integer(element, compiler, **kw):
 
 
 class TransactionBase(object):
-    issued_at = sa.Column(sa.DateTime, default=lambda: datetime.datetime.now(datetime.timezone.utc))
+    issued_at = sa.Column(sa.DateTime(timezone=True), default=lambda: datetime.datetime.now(datetime.timezone.utc))
 
     @property
     def entity_names(self):


### PR DESCRIPTION
This tries to solve an error while inserting transactions due to invalid datetime parameter