### PR TITLE
refactor: Remove cached_property dep and use functools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ version = "0"
 authors = ["Corridor Platforms <postmaster@corridorplatforms.com>"]
 license = "Apache-2.0, BSD-3-Clause"
 readme = "docs/README.md"
-packages = [{include = "sqlalchemy_history"}]
+packages = [{ include = "sqlalchemy_history" }]
 repository = "https://github.com/corridor/sqlalchemy-history"
-classifiers=[
+classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
@@ -24,7 +24,6 @@ python = "^3.9"
 
 SQLAlchemy = ">=2"
 SQLAlchemy-Utils = ">=0.30.12"
-cached-property = "*"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "*"

--- a/sqlalchemy_history/version.py
+++ b/sqlalchemy_history/version.py
@@ -1,6 +1,5 @@
 import sqlalchemy as sa
-from cached_property import cached_property
-
+import functools
 from sqlalchemy_history.reverter import Reverter
 from sqlalchemy_history.utils import (
     get_versioning_manager,
@@ -10,7 +9,7 @@ from sqlalchemy_history.utils import (
 
 
 class VersionClassBase(object):
-    @cached_property
+    @functools.cached_property
     def previous(self):
         """Returns the previous version relative to this version in the version
         history. If current version is the first version this method returns
@@ -20,7 +19,7 @@ class VersionClassBase(object):
         """
         return get_versioning_manager(self).fetcher(parent_class(self.__class__)).previous(self)
 
-    @cached_property
+    @functools.cached_property
     def next(self):
         """Returns the next version relative to this version in the version
         history. If current version is the last version this method returns
@@ -30,7 +29,7 @@ class VersionClassBase(object):
         """
         return get_versioning_manager(self).fetcher(parent_class(self.__class__)).next(self)
 
-    @cached_property
+    @functools.cached_property
     def index(self):
         """ """
         return get_versioning_manager(self).fetcher(parent_class(self.__class__)).index(self)


### PR DESCRIPTION
Python 3.8 added functools.cached_property and we only support python3.9+. So this dependency is no longer required