### PR TITLE
fix(#153): Ghost objects removed from the in-memory python list of the parent

### DIFF
--- a/sqlalchemy_history/reverter.py
+++ b/sqlalchemy_history/reverter.py
@@ -70,9 +70,11 @@ class Reverter:
                 if value:
                     values.append(value)
 
-            for value in getattr(self.version_parent, prop.key, []):
+            collection = getattr(self.version_parent, prop.key, [])
+            for value in list(collection):
                 if value not in values:
                     self.session.delete(value)
+                    collection.remove(value)
         else:
             self.revert_child(getattr(self.obj, prop.key), prop)
 

--- a/sqlalchemy_history/unit_of_work.py
+++ b/sqlalchemy_history/unit_of_work.py
@@ -5,7 +5,7 @@ from copy import copy
 import sqlalchemy as sa
 from sqlalchemy_utils import get_primary_keys, identity
 
-from sqlalchemy_history.operation import Operations
+from sqlalchemy_history.operation import Operation, Operations
 from sqlalchemy_history.schema import update_end_tx_column
 from sqlalchemy_history.utils import (
     end_tx_column_name,
@@ -296,9 +296,13 @@ class UnitOfWork:
         :param version_obj: Version object to assign the attribute values to
 
         """
+        state = sa.inspect(parent_obj)
         for prop in versioned_column_properties(parent_obj):
-            try:
-                value = getattr(parent_obj, prop.key)
-            except sa.orm.exc.ObjectDeletedError:
+            if version_obj.operation_type == Operation.DELETE and prop.key in state.unloaded:
                 value = None
+            else:
+                try:
+                    value = getattr(parent_obj, prop.key)
+                except sa.orm.exc.ObjectDeletedError:
+                    value = None
             setattr(version_obj, prop.key, value)

--- a/tests/revert/test_polymorphic_relationship.py
+++ b/tests/revert/test_polymorphic_relationship.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+
 from tests import TestCase
 
 
@@ -11,9 +12,7 @@ class TestRevertPolymorphicRelationship(TestCase):
             id = sa.Column(
                 sa.Integer, sa.Sequence(f"{__tablename__}_seq", start=1), autoincrement=True, primary_key=True
             )
-            parts = sa.orm.relationship(
-                "Part", back_populates="car", cascade="all, delete-orphan", lazy="selectin"
-            )
+            parts = sa.orm.relationship("Part", back_populates="car", cascade="all, delete-orphan", lazy="selectin")
 
         class Part(self.Model):
             __tablename__ = "part"
@@ -25,11 +24,11 @@ class TestRevertPolymorphicRelationship(TestCase):
             car_id = sa.Column(sa.Integer, sa.ForeignKey(Car.id))
             car = sa.orm.relationship(Car, back_populates="parts")
 
-            type = sa.Column(sa.String(50))
+            part_type = sa.Column(sa.String(50))
 
             __mapper_args__ = {
                 "polymorphic_identity": "part",
-                "polymorphic_on": type,
+                "polymorphic_on": part_type,
             }
 
         class Tire(Part):
@@ -62,5 +61,4 @@ class TestRevertPolymorphicRelationship(TestCase):
 
         assert len(reverted_car.parts) == 0
 
-        with pytest.raises(IndexError):
-            print(reverted_car.parts[0])
+        self.session.flush()

--- a/tests/revert/test_polymorphic_relationship.py
+++ b/tests/revert/test_polymorphic_relationship.py
@@ -1,0 +1,66 @@
+import sqlalchemy as sa
+from tests import TestCase
+
+
+class TestRevertPolymorphicRelationship(TestCase):
+    def create_models(self):
+        class Car(self.Model):
+            __tablename__ = "car"
+            __versioned__ = {}
+
+            id = sa.Column(
+                sa.Integer, sa.Sequence(f"{__tablename__}_seq", start=1), autoincrement=True, primary_key=True
+            )
+            parts = sa.orm.relationship(
+                "Part", back_populates="car", cascade="all, delete-orphan", lazy="selectin"
+            )
+
+        class Part(self.Model):
+            __tablename__ = "part"
+            __versioned__ = {}
+
+            id = sa.Column(
+                sa.Integer, sa.Sequence(f"{__tablename__}_seq", start=1), autoincrement=True, primary_key=True
+            )
+            car_id = sa.Column(sa.Integer, sa.ForeignKey(Car.id))
+            car = sa.orm.relationship(Car, back_populates="parts")
+
+            type = sa.Column(sa.String(50))
+
+            __mapper_args__ = {
+                "polymorphic_identity": "part",
+                "polymorphic_on": type,
+            }
+
+        class Tire(Part):
+            __tablename__ = "tire"
+            __versioned__ = {}
+
+            id = sa.Column(sa.Integer, sa.ForeignKey(Part.id), primary_key=True)
+            radius = sa.Column(sa.Integer)
+            width = sa.Column(sa.Integer)
+
+            __mapper_args__ = {
+                "polymorphic_identity": "tire",
+            }
+
+        self.Car = Car
+        self.Part = Part
+        self.Tire = Tire
+
+    def test_revert_polymorphic_relationship(self):
+        car = self.Car()
+        self.session.add(car)
+        self.session.commit()
+
+        tire = self.Tire(radius=15, width=200)
+        car.parts.append(tire)
+        self.session.commit()
+
+        initial_version = car.versions.all()[0]
+        reverted_car = initial_version.revert(relations=["parts"])
+
+        assert len(reverted_car.parts) == 0
+
+        with pytest.raises(IndexError):
+            print(reverted_car.parts[0])


### PR DESCRIPTION
When we were reverting a relationship where a child object was marked for deletion, it was not being removed from the Python's in-memory data-structure (collection). This left 'ghost' objects in the collection. If an autoFlush occurred, SQLAlchemy attempted to lazy-load deferred columns for these ghost objects, causing a KeyError: Deferred loader failed crash, which was especially prevalent if we had a polymorphic sub-class. This fix ensures the items are actively removed from the collection list in memory using collection.remove(value), keeping the Python state perfectly synced with the database session state.