### PR TITLE
feat: Add an option to opt-in for `write_only` loader in `versions` relationship

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run --no-sync pytest --maxfail=100 --cov --cov-report=lcov
+          uv run --no-sync pytest -v --maxfail=100 --cov --cov-report=lcov
         env:
           DB: ${{ matrix.DB }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,19 +14,16 @@
 git clone https://github.com/corridor/sqlalchemy-history.git
 cd sqlalchemy-history
 ```
-- Install Poetry in your local system
+- Install uv in your local system
 ```
-# Refer https://python-poetry.org/docs/#installation 
-curl -sSL https://install.python-poetry.org | python3 -
+# Refer https://docs.astral.sh/uv/getting-started/installation
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 - Install requirements of project into virtual environment.
 ```
-poetry install   # Poetry creates a virtual environment in your local
-# NOTE: If poetry is not set in your $PATH variable you can use
-# '~/.local/share/pypoetry/venv/bin/poetry install' instead!
-
-# Activate this virtual environment in your local by calling
-poetry shell
+uv venv venv --python 3.13 --seed
+source venv/bin/activate
+uv sync --active --dev
 ```
 - Checkout branch with name relevant to issue issue you are working
 ```
@@ -40,11 +37,11 @@ git checkout -b add-issue-num
 - Before commiting, verify if the changes are working in your local system
 ```
 # Run tests locally
-DB=sqlite poetry run pytest
+DB=sqlite DB=sqlite uv run --active pytest
 
 # Lint & Format
-poetry run ruff format .
-poetry run ruff check --fix .
+uv run --active ruff format .
+uv run --active ruff check --fix .
 ```
 - Add commit for your changes with message title and message description brifly explaining the approach
     - Keep commit message title 72 characters
@@ -65,6 +62,6 @@ A long description of what you are trying to change in this commit.
 ```
 git push origin <branch-name>
 ```
-- Got to github, and raise a PR `corridor/sqlalchemy-history:master` and wait for a review.
+- Got to github, and raise a PR `corridor/sqlalchemy-history:main` and wait for a review.
 - Maintainer(s) of the project will review and approve the CI flow to validate changes across different environments.
 - If changes are valid and passes all the tests, maintainer(s) will accept the PR(s)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,6 +89,10 @@ Here is a full list of configuration options:
 - operation_type_column_name (default: 'operation_type')
   The name of the operation type column (used by history tables).
 
+- support_async (default: False)
+  When enabled, the parent `.versions` relationship uses SQLAlchemy's `write_only`
+  loader instead of the legacy `dynamic` loader.
+
 - strategy (default: 'validity')
   The versioning strategy to use. Either 'validity' or 'subquery'
 
@@ -97,6 +101,7 @@ Example
 ```python
 >>> class Article(Base):
 ...     __versioned__ = {
+...         'support_async': True,
 ...         'transaction_column_name': 'tx_id'
 ...     }
 ...     __tablename__ = 'user'

--- a/sqlalchemy_history/manager.py
+++ b/sqlalchemy_history/manager.py
@@ -84,6 +84,7 @@ class VersioningManager:
             "table_name": "%s_version",
             "exclude": [],
             "include": [],
+            "support_async": False,
             "create_models": True,
             "create_tables": True,
             "transaction_column_name": "transaction_id",

--- a/sqlalchemy_history/model_builder.py
+++ b/sqlalchemy_history/model_builder.py
@@ -125,12 +125,14 @@ class ModelBuilder:
         # We need to check if versions relation was already set for parent
         # class.
         if not hasattr(self.model, "versions"):
+            # Keep legacy dynamic loading by default, but allow SQLAlchemy 2.x
+            # style write-only access for version collections when support_async=True
             self.model.versions = sa.orm.relationship(
                 self.version_class,
                 primaryjoin=sa.and_(*conditions),
                 foreign_keys=foreign_keys,
                 order_by=lambda: getattr(self.version_class, option(self.model, "transaction_column_name")),
-                lazy="dynamic",
+                lazy="write_only" if self.manager.options["support_async"] else "dynamic",
                 viewonly=True,
             )
             # We must explicitly declare this relationship, instead of

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -59,6 +59,7 @@ class TestCase:
             "create_models": self.should_create_models,
             "base_classes": (self.Model,),
             "strategy": self.versioning_strategy,
+            "support_async": False,
             "transaction_column_name": self.transaction_column_name,
             "end_transaction_column_name": self.end_transaction_column_name,
         }

--- a/tests/builders/test_model_builder.py
+++ b/tests/builders/test_model_builder.py
@@ -9,8 +9,32 @@ class TestVersionModelBuilder(TestCase):
     def test_builds_relationship(self):
         assert self.Article.versions
 
+    def test_versions_relationship_is_dynamic_by_default(self):
+        assert sa.inspect(self.Article).relationships.versions.lazy == "dynamic"
+
     def test_parent_has_access_to_versioning_manager(self):
         assert self.Article.__versioning_manager__
+
+
+class TestVersionModelBuilderAsync(TestCase):
+    @property
+    def options(self):
+        options = super().options
+        options["support_async"] = True
+        return options
+
+    def test_versions_relationship_is_write_only_with_async_support(self):
+        assert sa.inspect(self.Article).relationships.versions.lazy == "write_only"
+
+    def test_versions_can_be_loaded_with_select(self):
+        article = self.Article(name="testing")
+        self.session.add(article)
+        self.session.commit()
+
+        versions = self.session.scalars(article.versions.select()).all()
+
+        assert len(versions) == 1
+        assert versions[0].name == "testing"
 
 
 class TestGenericReprModelBuilder(TestCase):
@@ -20,6 +44,7 @@ class TestGenericReprModelBuilder(TestCase):
             "create_models": self.should_create_models,
             "base_classes": None,
             "strategy": self.versioning_strategy,
+            "support_async": False,
             "transaction_column_name": self.transaction_column_name,
             "end_transaction_column_name": self.end_transaction_column_name,
         }
@@ -43,6 +68,7 @@ class TestNoGenericReprModelBuilder(TestCase):
             "create_models": self.should_create_models,
             "base_classes": (self.Model, ReprMixin),
             "strategy": self.versioning_strategy,
+            "support_async": False,
             "transaction_column_name": self.transaction_column_name,
             "end_transaction_column_name": self.end_transaction_column_name,
         }

--- a/tests/utils/test_option.py
+++ b/tests/utils/test_option.py
@@ -14,6 +14,7 @@ class TestOption(TestCase):
             "table_name",
             "exclude",
             "include",
+            "support_async",
             "create_models",
             "create_tables",
             "transaction_column_name",


### PR DESCRIPTION
After https://github.com/corridor/sqlalchemy-history/pull/156 the only place still relying on Query/AppederQuery is the `versions` relationship on versioned classes that use `lazy='dynamic'` strategy. `dynamic` is superseded by `write_only` in sqla 2.x. 

This is a public API change, add an option to opt-in to this loader for `versions`