### PR TITLE
fix(#152): match issued_at default to naive column schema

### DIFF
--- a/sqlalchemy_history/transaction.py
+++ b/sqlalchemy_history/transaction.py
@@ -16,7 +16,9 @@ def compile_big_integer(element, compiler, **kw):
 
 
 class TransactionBase:
-    issued_at = sa.Column(sa.DateTime, default=lambda: datetime.datetime.now(datetime.timezone.utc))
+    issued_at = sa.Column(
+        sa.DateTime, default=lambda: datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+    )
 
     @property
     def entity_names(self):

--- a/tests/relationships/test_many_to_many_relations.py
+++ b/tests/relationships/test_many_to_many_relations.py
@@ -34,7 +34,7 @@ class ManyToManyRelationshipsTestCase(TestCase):
                 sa.DateTime,
                 nullable=False,
                 server_default=sa.func.current_timestamp(),
-                default=lambda: datetime.datetime.now(datetime.timezone.utc),
+                default=lambda: datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
             ),
         )
 

--- a/tests/reported_bugs/test_bug_27_datetime_insertion_issue.py
+++ b/tests/reported_bugs/test_bug_27_datetime_insertion_issue.py
@@ -19,7 +19,7 @@ class TestBug27(TestCase):
                 sa.DateTime,
                 nullable=False,
                 server_default=sa.func.current_timestamp(),
-                default=lambda: datetime.datetime.now(datetime.timezone.utc),
+                default=lambda: datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
             ),
         )
 

--- a/tests/schema/test_update_end_transaction_id.py
+++ b/tests/schema/test_update_end_transaction_id.py
@@ -24,7 +24,7 @@ class UpdateEndTransactionID(TestCase):
                 sa.DateTime,
                 nullable=False,
                 server_default=sa.func.current_timestamp(),
-                default=lambda: datetime.datetime.now(datetime.timezone.utc),
+                default=lambda: datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
             ),
         )
 

--- a/tests/test_hybrid_property.py
+++ b/tests/test_hybrid_property.py
@@ -18,7 +18,9 @@ class TestHybridProperty(TestCase):
             name = sa.Column(sa.Unicode(255), nullable=False)
             content = sa.Column(sa.UnicodeText)
             description = sa.Column(sa.UnicodeText)
-            publish = sa.Column(sa.DateTime, default=lambda: datetime.datetime.now(datetime.timezone.utc))
+            publish = sa.Column(
+                sa.DateTime, default=lambda: datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+            )
 
             author_id = sa.Column(sa.Integer, sa.ForeignKey("article_author.id"), nullable=False)
 

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import time
 
@@ -50,6 +51,13 @@ class TestTransaction(TestCase):
         self.session.add(self.article)
         self.session.commit()
         assert self.article.versions[0].transaction.issued_at != self.article.versions[1].transaction.issued_at
+
+    def test_transaction_issued_at_is_naive(self):
+        uow = versioning_manager.unit_of_work(self.session)
+        tx = uow.create_transaction(self.session)
+
+        assert isinstance(tx.issued_at, datetime.datetime)
+        assert tx.issued_at.tzinfo is None
 
 
 # Check that the tests pass without TransactionChangesPlugin

--- a/tests/utils/test_parent_table.py
+++ b/tests/utils/test_parent_table.py
@@ -21,7 +21,7 @@ class TestParentTable(TestCase):
                 sa.DateTime,
                 nullable=False,
                 server_default=sa.func.current_timestamp(),
-                default=lambda: datetime.datetime.now(datetime.timezone.utc),
+                default=lambda: datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
             ),
         )
 

--- a/tests/utils/test_version_table.py
+++ b/tests/utils/test_version_table.py
@@ -22,7 +22,7 @@ class TestVersionTableDefault(TestCase):
                 sa.DateTime,
                 nullable=False,
                 server_default=sa.func.current_timestamp(),
-                default=lambda: datetime.datetime.now(datetime.timezone.utc),
+                default=lambda: datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
             ),
         )
 


### PR DESCRIPTION
The `issued_at` column is defined as a timezone-naive `DateTime`, but 
its default value (`datetime.now(timezone.utc)`) was returning a 
timezone-aware object. 

While some database drivers silently fix this mismatch for us behind 
the scenes, stricter ones will immediately crash with a `TypeError` 
during inserts. 

This commit fixes the root problem by explicitly removing the timezone 
info (`.replace(tzinfo=None)`) before the value hits the database. 
This ensures the data perfectly matches the expected column schema, 
preventing crashes across different environments. A regression test 
has also been added.