### PR TITLE
fix: use subscript access in versioned_column_properties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,15 @@ Changelog
 
 Here you can see the full list of changes between each release.
 
+Unreleased
+^^^^^^^^^^
+
+-   Fix ``versioned_column_properties`` (and the version-table builder) failing on
+    columns whose names shadow dict-API attributes of ``mapper.attrs`` such as
+    ``values``, ``keys``, or ``items``. Attribute access returned a bound method
+    instead of the column property, raising ``AttributeError: 'function' object
+    has no attribute 'key'`` on insert.
+
 2.1.4 (2026-04-13)
 ^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,11 +6,8 @@ Here you can see the full list of changes between each release.
 Unreleased
 ^^^^^^^^^^
 
--   Fix ``versioned_column_properties`` (and the version-table builder) failing on
-    columns whose names shadow dict-API attributes of ``mapper.attrs`` such as
-    ``values``, ``keys``, or ``items``. Attribute access returned a bound method
-    instead of the column property, raising ``AttributeError: 'function' object
-    has no attribute 'key'`` on insert.
+-   Fix ``versioned_column_properties`` failing on columns whose names shadow
+    ``mapper.attrs`` dict-API methods (e.g. ``values``, ``keys``, ``items``).
 
 2.1.4 (2026-04-13)
 ^^^^^^^^^^

--- a/sqlalchemy_history/utils.py
+++ b/sqlalchemy_history/utils.py
@@ -195,7 +195,10 @@ def versioned_column_properties(obj_or_class):
             continue
 
         if not manager.is_excluded_property(obj_or_class, key):
-            yield getattr(mapper.attrs, key)
+            # Use subscript access: attribute access via getattr collides with
+            # dict-API methods on the namespace (e.g. a column named ``values``
+            # would resolve to ``ReadOnlyProperties.values``).
+            yield mapper.attrs[key]
 
 
 def versioned_relationships(obj, versioned_column_keys):

--- a/tests/reported_bugs/test_bug_versioned_column_properties_dict_api_collision.py
+++ b/tests/reported_bugs/test_bug_versioned_column_properties_dict_api_collision.py
@@ -1,0 +1,40 @@
+from copy import copy
+
+import sqlalchemy as sa
+
+from sqlalchemy_history import version_class
+from tests import TestCase
+
+
+class TestVersionedColumnPropertiesDictAPICollision(TestCase):
+    # Regression test for ``versioned_column_properties`` resolving column
+    # names that shadow dict-API methods on ``mapper.attrs`` (e.g. ``values``,
+    # ``keys``, ``items``). Attribute access used to return a bound method
+    # instead of the column property, which made inserts on such models fail.
+    def create_models(self):
+        class Measurement(self.Model):
+            __tablename__ = "measurement"
+            __versioned__ = copy(self.options)
+
+            id = sa.Column(
+                sa.Integer,
+                sa.Sequence(f"{__tablename__}_seq", start=1),
+                autoincrement=True,
+                primary_key=True,
+            )
+            values = sa.Column(sa.Integer)
+            keys = sa.Column(sa.Unicode(255))
+            items = sa.Column(sa.Unicode(255))
+
+        self.Measurement = Measurement
+
+    def test_insert_with_shadowing_column_names(self):
+        measurement = self.Measurement(values=42, keys="k", items="i")
+        self.session.add(measurement)
+        self.session.commit()
+
+        MeasurementVersion = version_class(self.Measurement)
+        version = self.session.scalars(sa.select(MeasurementVersion)).one()
+        assert version.values == 42
+        assert version.keys == "k"
+        assert version.items == "i"


### PR DESCRIPTION
## Summary

`versioned_column_properties` (and the version-table builder that consumes it) currently fails on any model with a column whose name shadows a dict-API attribute of `mapper.attrs` — most notably `values`, `keys`, or `items`.

`getattr(mapper.attrs, key)` resolves to the bound method on the underlying `ReadOnlyProperties` namespace rather than the `ColumnProperty`, so the next `prop.key` access in `utils.py` raises:

```
AttributeError: 'function' object has no attribute 'key'
```

This blocks inserts on otherwise-valid versioned models. Switching to subscript (`mapper.attrs[key]`) bypasses normal attribute resolution and always returns the mapped property.

## Changes

- `sqlalchemy_history/utils.py`: swap `getattr(mapper.attrs, key)` for `mapper.attrs[key]` in `versioned_column_properties`.
- `tests/reported_bugs/`: new regression test using a model with `values`, `keys`, and `items` columns. Verified to reproduce the original `AttributeError` against unfixed `utils.py` and to pass after the fix.
- `CHANGES.rst`: add an Unreleased entry describing the fix.

## Test plan

- [x] New regression test passes against patched `utils.py`
- [x] New regression test fails on `main` with the documented `AttributeError`
- [x] `ruff check` and `ruff format --check` clean on changed files
- [x] No change in pass/fail counts on `tests/relationships/` between fixed and unfixed builds (pre-existing failures are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)