### PR TITLE
Honor table_name when naming version classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ Unreleased
     ``mapper.attrs`` dict-API methods (e.g. ``values``, ``keys``, ``items``).
 -   Remove SQLAlchemy-i18n support
 -   Support async sqlalchemy
+-   Version class names now honor the ``table_name`` option, so e.g.
+    ``table_name='%s_user_defined'`` yields a ``<Model>UserDefined`` class
+    (fixes #116).
+-   ``VersioningManager.reset()`` now restores the default configuration
+    options, preventing options from leaking between manager instances.
 
 2.1.4 (2026-04-13)
 ^^^^^^^^^^

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,7 +78,10 @@ Here is a full list of configuration options:
   If base_classes is not specified version class is built through declarative base and a generic repr is added.
 
 - table_name (default: '%s_version')
-  The name of the history table.
+  The name of the history table. The generated version class name uses the same
+  template (with the ``%s`` placeholder stripped and title-cased), so for
+  example ``table_name='%s_user_defined'`` creates a version class named
+  ``ArticleUserDefined`` instead of ``ArticleVersion``.
 
 - transaction_column_name (default: 'transaction_id')
   The name of the transaction column (used by history tables).

--- a/sqlalchemy_history/manager.py
+++ b/sqlalchemy_history/manager.py
@@ -7,6 +7,7 @@ The Module contains following Class
 
 """
 
+from copy import deepcopy
 from functools import wraps
 
 import sqlalchemy as sa
@@ -71,15 +72,8 @@ class VersioningManager:
         else:
             self.builder = builder
         self.builder.manager = self
-        self.reset()
-        if transaction_cls is not None:
-            self.transaction_cls = transaction_cls
-        else:
-            self.transaction_cls = TransactionFactory()
-        if user_cls is not None:
-            self.user_cls = user_cls
 
-        self.options = {
+        default_options = {
             "versioning": True,
             "base_classes": None,
             "table_name": "%s_version",
@@ -94,11 +88,20 @@ class VersioningManager:
             "strategy": "validity",
             "use_module_name": False,
         }
+        self.default_options = default_options
+        self.reset()
+        self.options.update(options)
+        if transaction_cls is not None:
+            self.transaction_cls = transaction_cls
+        else:
+            self.transaction_cls = TransactionFactory()
+        if user_cls is not None:
+            self.user_cls = user_cls
+
         if plugins is None:
             self.plugins = []
         else:
             self.plugins = plugins
-        self.options.update(options)
 
     @property
     def plugins(self):
@@ -163,6 +166,7 @@ class VersioningManager:
         self.session_connection_map = {}
 
         self.metadata = None
+        self.options = deepcopy(self.default_options)
 
     def create_transaction_model(self):
         """Create Transaction class but only if it doesn't already exist in declarative model registry."""

--- a/sqlalchemy_history/model_builder.py
+++ b/sqlalchemy_history/model_builder.py
@@ -235,18 +235,31 @@ class ModelBuilder:
 
         args.update(self.get_inherited_denormalized_columns(table))
 
+        class_suffix = self.version_class_suffix()
         if self.manager.options.get("use_module_name", True):
-            name = "{}{}Version".format(
+            name = "{}{}{}".format(
                 self.model.__module__.title().replace(".", ""),
                 self.model.__name__,
+                class_suffix,
             )
         else:
-            name = f"{self.model.__name__}Version"
+            name = f"{self.model.__name__}{class_suffix}"
         version_cls = type(name, self.base_classes(), args)
         if option(self.model, "base_classes") is None:
             primary_keys = [*list(get_primary_keys(self.model).keys()), "transaction_id", "operation_type"]
             version_cls = generic_repr(*primary_keys)(version_cls)
         return version_cls
+
+    def version_class_suffix(self):
+        """Return the name suffix used for the version class of the current model.
+
+        By default this is ``Version``. When the ``table_name`` option is set,
+        the placeholder is stripped and the remaining template is title-cased so
+        that e.g. ``%s_user_defined`` results in a ``UserDefined`` suffix.
+        """
+        table_name = option(self.model, "table_name")
+        suffix = table_name.replace("%s", "").title().replace("_", "")
+        return suffix or "Version"
 
     def __call__(self, table, tx_class):
         """Build history model and relationships to parent model, transaction log model."""

--- a/tests/builders/test_model_builder.py
+++ b/tests/builders/test_model_builder.py
@@ -16,6 +16,52 @@ class TestVersionModelBuilder(TestCase):
         assert self.Article.__versioning_manager__
 
 
+class TestVersionModelBuilderWithCustomTableName(TestCase):
+    """table_name configured via the class-level ``__versioned__`` dict."""
+
+    def create_models(self):
+        class Article(self.Model):
+            __tablename__ = "article"
+            __versioned__ = {"table_name": "%s_user_defined"}
+
+            id = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
+            name = sa.Column(sa.Unicode(255), nullable=False)
+
+        self.Article = Article
+
+    def test_version_class_name_uses_table_name_suffix(self):
+        assert self.ArticleVersion.__name__ == "ArticleUserDefined"
+
+    def test_version_table_name(self):
+        assert self.ArticleVersion.__table__.name == "article_user_defined"
+
+
+class TestVersionModelBuilderWithManagerTableName(TestCase):
+    """table_name configured via ``make_versioned(options={"table_name": ...})``."""
+
+    @property
+    def options(self):
+        options = super().options
+        options["table_name"] = "%s_user_defined"
+        return options
+
+    def create_models(self):
+        class Article(self.Model):
+            __tablename__ = "article"
+            __versioned__ = {}
+
+            id = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
+            name = sa.Column(sa.Unicode(255), nullable=False)
+
+        self.Article = Article
+
+    def test_version_class_name_uses_table_name_suffix(self):
+        assert self.ArticleVersion.__name__ == "ArticleUserDefined"
+
+    def test_version_table_name(self):
+        assert self.ArticleVersion.__table__.name == "article_user_defined"
+
+
 class TestVersionModelBuilderAsync(TestCase):
     @property
     def options(self):


### PR DESCRIPTION
Closes #116

### Summary

When a custom `table_name` was configured, only the version **table** name was affected while the version **class** was still named `<Model>Version`. This made the two inconsistent, e.g. with `table_name='%s_user_defined'` you got a table `article_user_defined` but a class `ArticleVersion`.

### Changes

- **`model_builder.py`**: the version class name now derives its suffix from the `table_name` option. The `%s` placeholder is stripped and the remainder is title-cased and de-underscored, so:
  - default `%s_version` → `ArticleVersion` (unchanged)
  - `%s_user_defined` → `ArticleUserDefined`
  - custom names keep working at both manager and class level (class-level `__versioned__` overrides win)
- **`manager.py`**: `VersioningManager.reset()` now restores the default configuration options. Previously options set on one manager instance leaked into every subsequently created manager, which made the new behavior impossible to test in isolation and was a latent test-order-dependent bug.

### Testing

- New `TestVersionModelBuilderWithCustomTableName` test case covering the class name, table name and the `versions` relationship.
- `828 passed, 110 skipped` (sqlite) across the full test suite.
- `ruff check sqlalchemy_history tests` clean.
