### PR TITLE
fix(#86): Handle identity columns (sa.Identity) in version table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Here you can see the full list of changes between each release.
 Unreleased
 ^^^^^^^^^^
 
+-   Fix version-table generation for parent columns that use ``sa.Identity()``
+
 2.1.6 (2026-08-26)
 ^^^^^^^^^^^^^^^^^^
 

--- a/sqlalchemy_history/table_builder.py
+++ b/sqlalchemy_history/table_builder.py
@@ -28,6 +28,7 @@ class ColumnReflector:
         column_copy.onupdate = None
         column_copy.default = None
         column_copy.server_default = None
+        column_copy.identity = None
         if column_copy.autoincrement:
             column_copy.autoincrement = False
         if column_copy.name == self.option("transaction_column_name"):

--- a/tests/builders/test_table_builder.py
+++ b/tests/builders/test_table_builder.py
@@ -79,6 +79,49 @@ class TestTableBuilderWithOnUpdate(TestCase):
         assert table.c.last_update.default is None
 
 
+class TestTableBuilderWithIdentity(TestCase):
+    def create_models(self):
+        class Article(self.Model):
+            __tablename__ = "article"
+            __versioned__ = copy(self.options)
+
+            id = sa.Column(sa.Integer, sa.Identity(), primary_key=True, autoincrement=True)
+            name = sa.Column(sa.Unicode(255))
+
+        self.Article = Article
+
+    def test_removes_identity_from_version_column(self):
+        parent_column = self.Article.__table__.c.id
+        version_column = version_class(self.Article).__table__.c.id
+
+        assert parent_column.identity is not None
+        assert parent_column.autoincrement is True
+        assert version_column.identity is None
+        assert version_column.server_default is None
+        assert version_column.autoincrement is False
+
+    def test_version_table_ddl_does_not_emit_identity(self):
+        table = version_class(self.Article).__table__
+        ddl = str(sa.schema.CreateTable(table).compile())
+
+        assert "IDENTITY" not in ddl
+
+    def test_populates_version_column_from_parent_identity(self):
+        article = self.Article(name="First name")
+        self.session.add(article)
+        self.session.commit()
+
+        article.name = "Updated name"
+        self.session.commit()
+
+        version_model = version_class(self.Article)
+        versions = self.session.scalars(sa.select(version_model).order_by(version_model.transaction_id)).all()
+
+        assert article.id is not None
+        assert len(versions) == 2
+        assert [version.id for version in versions] == [article.id, article.id]
+
+
 @pytest.mark.skipif(os.environ.get("DB") == "sqlite", reason="sqlite doesn't have a concept of schema")
 class TestTableBuilderInOtherSchema(TestCase):
     def create_models(self):

--- a/tests/inheritance/test_join_table_inheritance.py
+++ b/tests/inheritance/test_join_table_inheritance.py
@@ -178,3 +178,58 @@ class TestDeepJoinedTableInheritance(TestCase):
         assert self.session.execute(sa.text("SELECT COUNT(1) FROM document_version")).scalar() == 1
         assert self.session.execute(sa.text("SELECT COUNT(1) FROM content_version")).scalar() == 1
         assert self.session.execute(sa.text("SELECT COUNT(1) FROM node_version")).scalar() == 1
+
+
+class TestDeepJoinedTableInheritanceWithIdentity(TestCase):
+    def create_models(self):
+        class Node(self.Model):
+            __versioned__ = {}
+            __tablename__ = "node"
+            __mapper_args__ = {
+                "polymorphic_on": "type",
+                "polymorphic_identity": "node",
+                "with_polymorphic": "*",
+            }
+
+            id = sa.Column(sa.Integer, sa.Identity(), primary_key=True)
+            type = sa.Column(sa.String(30), nullable=False)
+
+        class Content(Node):
+            __versioned__ = {}
+            __tablename__ = "content"
+            __mapper_args__ = {"polymorphic_identity": "content"}
+            id = sa.Column(
+                sa.Integer,
+                sa.ForeignKey("node.id"),
+                autoincrement=False,
+                primary_key=True,
+            )
+            description = sa.Column(sa.UnicodeText())
+
+        class Document(Content):
+            __versioned__ = {}
+            __tablename__ = "document"
+            __mapper_args__ = {"polymorphic_identity": "document"}
+            id = sa.Column(
+                sa.Integer,
+                sa.ForeignKey("content.id"),
+                primary_key=True,
+                autoincrement=False,
+            )
+            body = sa.Column(sa.UnicodeText)
+
+        self.Node = Node
+        self.Content = Content
+        self.Document = Document
+
+    def test_insert_with_identity(self):
+        document = self.Document()
+        self.session.add(document)
+        self.session.commit()
+
+        assert self.session.execute(sa.text("SELECT COUNT(1) FROM document_version")).scalar() == 1
+        assert self.session.execute(sa.text("SELECT COUNT(1) FROM content_version")).scalar() == 1
+        assert self.session.execute(sa.text("SELECT COUNT(1) FROM node_version")).scalar() == 1
+        assert self.session.execute(sa.text("SELECT id FROM document_version")).scalar() == document.id
+        assert self.session.execute(sa.text("SELECT id FROM content_version")).scalar() == document.id
+        assert self.session.execute(sa.text("SELECT id FROM node_version")).scalar() == document.id


### PR DESCRIPTION
Ensure identity generation metadata is not copied from a model column to
its version counterpart. History rows reuse the parent row's identifier
and must never generate a new one.

Fixes: #86
