### PR TITLE
docs: add Contributing quick-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,3 +194,8 @@ We found multiple libraries which has an implementation of history tracking:
     - Uses django ORM, does not support sqlalchemy
 6. [sqlalchemy example versioning-objects](http://docs.sqlalchemy.org/en/latest/orm/examples.html#versioning-objects)
     - Simple example to demonstrate implementation - but very minimal
+
+## Contributing
+
+Thanks for considering contributions! Please run tests via `pytest` or `cargo test` and ensure lint passes (`ruff check .` / `cargo fmt`) before opening a PR. See `CONTRIBUTING.md` if present.
+


### PR DESCRIPTION
Hello! Small docs improvement:
- adds a Contributing section to README with the project's standard pytest + ruff check quick-start
- helps new contributors (e.g., from good first issue) get running without hunting through CONTRIBUTING.md

No code change, just a 5-line README addition. Happy to tweak wording.
